### PR TITLE
Allow letter-spacing to have values up to 2 precision

### DIFF
--- a/packages/zeplin-extension-style-kit/common.d.ts
+++ b/packages/zeplin-extension-style-kit/common.d.ts
@@ -31,6 +31,11 @@ declare namespace zesk {
         densityDivisor: number;
     }
 
+    interface LengthOptions {
+        unit?: string;
+        precision?: number;
+    }
+
     interface StyleFunction {
         fn: string,
         args: Array<string | StyleValue>

--- a/packages/zeplin-extension-style-kit/declarations/letterSpacing.js
+++ b/packages/zeplin-extension-style-kit/declarations/letterSpacing.js
@@ -8,7 +8,7 @@ class LetterSpacing {
     }
 
     static get DEFAULT_VALUE() {
-        return new Length(0);
+        return 0;
     }
 
     get name() {
@@ -16,11 +16,11 @@ class LetterSpacing {
     }
 
     hasDefaultValue() {
-        return this.value.equals(LetterSpacing.DEFAULT_VALUE);
+        return this.value === LetterSpacing.DEFAULT_VALUE;
     }
 
     equals(other) {
-        return this.value.equals(other.value);
+        return this.value === other.value;
     }
 
     getValue(params, variables) {
@@ -28,7 +28,9 @@ class LetterSpacing {
             return "normal";
         }
 
-        return this.value.toStyleValue(params, variables);
+        const value = new Length(this.value, { precision: 2 });
+
+        return value.toStyleValue(params, variables);
     }
 }
 

--- a/packages/zeplin-extension-style-kit/docs/declarations.md
+++ b/packages/zeplin-extension-style-kit/docs/declarations.md
@@ -80,7 +80,7 @@ Returns the string representation.
 
 ```js
 new BackdropFilter([
-    { fn: "blur", args: [new Length(12, "px")] },
+    { fn: "blur", args: [new Length(12, { unit: "px" })] },
     { fn: "saturate", args: [new Percent(35)] }
 ]).getValue({ densityDivisor: 2 }) // "blur("6px") saturate(35%)"
 ```
@@ -249,7 +249,7 @@ Returns the string representation.
 ```js
 new Border({
     style: "solid",
-    width: new Length(2, "px"),
+    width: new Length(2, { unit: "px" }),
     color: black
 }).getValue({ densityDivisor: 2, colorFormat: "hex" }) // "solid 1px #000000"
 ```
@@ -332,7 +332,7 @@ Returns the string representation.
 - `variables`: A [`VariableMap`](./types.md#variablemap) instance.
 
 ```js
-new BorderRadius(new Length(22, "px")).getValue({ densityDivisor: 2 }) // "11px"
+new BorderRadius(new Length(22, { unit: "px" })).getValue({ densityDivisor: 2 }) // "11px"
 ```
 
 ## BorderStyle
@@ -384,7 +384,7 @@ Returns the string representation.
 - `variables`: A [`VariableMap`](./types.md#variablemap) instance.
 
 ```js
-new BorderWidth(new Length(2, "px")).getValue({ densityDivisor: 1 }) // "2px"
+new BorderWidth(new Length(2, { unit: "px" })).getValue({ densityDivisor: 1 }) // "2px"
 ```
 
 ## FontColor
@@ -441,7 +441,7 @@ Returns the string representation.
 
 ```js
 new Filter([
-    { fn: "blur", args: [new Length(12, "px")] },
+    { fn: "blur", args: [new Length(12, { unit: "px" })] },
     { fn: "saturate", args: [new Percent(35)] }
 ]).getValue({ densityDivisor: 2 }) // "blur("6px") saturate(35%)"
 ```
@@ -471,7 +471,7 @@ Returns the string representation.
 - `variables`: A [`VariableMap`](./types.md#variablemap) instance.
 
 ```js
-new FontSize(new Length(12, "px")).getValue({ densityDivisor: 1 }) // "12px"
+new FontSize(new Length(12, { unit: "px" })).getValue({ densityDivisor: 1 }) // "12px"
 ```
 
 ## FontStretch
@@ -571,16 +571,16 @@ Returns the string representation.
 - `variables`: A [`VariableMap`](./types.md#variablemap) instance.
 
 ```js
-new Height(new Length(12, "px")).getValue({ densityDivisor: 2 }) // "6px"
+new Height(new Length(12, { unit: "px" })).getValue({ densityDivisor: 2 }) // "6px"
 ```
 
 ## LetterSpacing
 
-### `constructor(length)`: `LetterSpacing`
+### `constructor(value)`: `LetterSpacing`
 Creates `letter-spacing` property instance with `length`. See [related docs](https://developer.mozilla.org/en-US/docs/Web/CSS/letter-spacing).
 
 #### Parameters:
-- `length`: [`Length`](./values.md#length).
+- `value`: `number`
 
 ### name: string
 Returns `letter-spacing`.
@@ -599,16 +599,17 @@ Returns the string representation.
 - `variables`: A [`VariableMap`](./types.md#variablemap) instance.
 
 ```js
-new LetterSpacing(new Length(4, "px")).getValue({ densityDivisor: 2 }) // "2px"
+new LetterSpacing(4).getValue({ densityDivisor: 2 }) // "2px"
 ```
 
 ## LineHeight
 
-### `constructor(length)`: `LineHeight`
+### `constructor(value, fontSize)`: `LineHeight`
 Creates `line-height` property instance with `length`. See [related docs](https://developer.mozilla.org/en-US/docs/Web/CSS/line-height).
 
 #### Parameters:
-- `length`: [`Length`](./values.md#length).
+- `value`: `number`
+- `fontSize`: `number`
 
 ### name: string
 Returns `line-height`.
@@ -627,7 +628,7 @@ Returns the string representation.
 - `variables`: A [`VariableMap`](./types.md#variablemap) instance.
 
 ```js
-new LineHeight(new Length(24, "px")).getValue({ densityDivisor: 2 }) // "12px"
+new LineHeight(24, 18).getValue({ densityDivisor: 2 }) // "12px"
 ```
 
 ## MixBlendMode
@@ -818,7 +819,7 @@ Returns the string representation.
 - `variables`: A [`VariableMap`](./types.md#variablemap) instance.
 
 ```js
-new TextStroke(new Length(3, "px"), black).getValue({ densityDivisor: 2, colorFormat: "hex" }) // "1.5px #000000"
+new TextStroke(new Length(3, { unit: "px" }), black).getValue({ densityDivisor: 2, colorFormat: "hex" }) // "1.5px #000000"
 ```
 
 ## Transform
@@ -873,5 +874,5 @@ Returns the string representation.
 - `variables`: A [`VariableMap`](./types.md#variablemap) instance.
 
 ```js
-new Width(new Length(120, "px")).getValue({ densityDivisor: 2 }) // "60px"
+new Width(new Length(120, { unit: "px" })).getValue({ densityDivisor: 2 }) // "60px"
 ```

--- a/packages/zeplin-extension-style-kit/docs/values.md
+++ b/packages/zeplin-extension-style-kit/docs/values.md
@@ -116,8 +116,8 @@ Returns the string representation.
 - `params`: An instance conforming to [`LengthParams`](./types.md#lengthparams).
 
 ```js
-new Length(22, "px").toStyleValue({ densityDivisor: 1 }) // "22px"
-new Length(22, "px").toStyleValue({ densityDivisor: 2 }) // "11px"
+new Length(22, { unit: "px" }).toStyleValue({ densityDivisor: 1 }) // "22px"
+new Length(22, { unit: "px" }).toStyleValue({ densityDivisor: 2 }) // "11px"
 ```
 
 ## Percent

--- a/packages/zeplin-extension-style-kit/elements/textStyle.js
+++ b/packages/zeplin-extension-style-kit/elements/textStyle.js
@@ -30,9 +30,7 @@ class TextStyle {
         declarations.push(new FontStyle(font.fontStyle || FontStyle.DEFAULT_VALUE));
         declarations.push(new FontStretch(font.fontStretch || FontStretch.DEFAULT_VALUE));
         declarations.push(new LineHeight(font.lineHeight || LineHeight.DEFAULT_VALUE, font.fontSize));
-        declarations.push(new LetterSpacing(
-            font.letterSpacing ? new Length(font.letterSpacing) : LetterSpacing.DEFAULT_VALUE
-        ));
+        declarations.push(new LetterSpacing(font.letterSpacing || LetterSpacing.DEFAULT_VALUE));
 
         if ("textAlign" in font && font.textAlign) {
             declarations.push(new TextAlign(font.textAlign));

--- a/packages/zeplin-extension-style-kit/tests/declarations/backdropFilter.test.js
+++ b/packages/zeplin-extension-style-kit/tests/declarations/backdropFilter.test.js
@@ -5,7 +5,7 @@ import Percent from "@root/values/percent";
 
 test("property name", () => {
     const backdropFilter = new BackdropFilter([
-        { fn: "blur", args: [new Length(13, "px")] }
+        { fn: "blur", args: [new Length(13, { unit: "px" })] }
     ]);
 
     expect(backdropFilter.name).toBe("backdrop-filter");
@@ -13,7 +13,7 @@ test("property name", () => {
 
 test("single filter", () => {
     const backdropFilter = new BackdropFilter([
-        { fn: "blur", args: [new Length(13, "px")] }
+        { fn: "blur", args: [new Length(13, { unit: "px" })] }
     ]);
 
     expect(backdropFilter.getValue({ densityDivisor: 1 })).toBe("blur(13px)");
@@ -21,7 +21,7 @@ test("single filter", () => {
 
 test("multiple filters", () => {
     const backdropFilter = new BackdropFilter([
-        { fn: "blur", args: [new Length(13, "px")] },
+        { fn: "blur", args: [new Length(13, { unit: "px" })] },
         { fn: "saturate", args: [new Percent(1.3)] }
     ]);
 
@@ -30,10 +30,10 @@ test("multiple filters", () => {
 
 test("equality check", () => {
     const backdropFilter = new BackdropFilter([
-        { fn: "blur", args: [new Length(13, "px")] }
+        { fn: "blur", args: [new Length(13, { unit: "px" })] }
     ]);
     const other = new BackdropFilter([
-        { fn: "blur", args: [new Length(13, "px")] }
+        { fn: "blur", args: [new Length(13, { unit: "px" })] }
     ]);
 
     expect(backdropFilter.equals(other)).toBe(true);
@@ -41,11 +41,11 @@ test("equality check", () => {
 
 test("equality check (multiple filters in same order)", () => {
     const backdropFilter = new BackdropFilter([
-        { fn: "blur", args: [new Length(13, "px")] },
+        { fn: "blur", args: [new Length(13, { unit: "px" })] },
         { fn: "saturate", args: [new Percent(1.3)] }
     ]);
     const other = new BackdropFilter([
-        { fn: "blur", args: [new Length(13, "px")] },
+        { fn: "blur", args: [new Length(13, { unit: "px" })] },
         { fn: "saturate", args: [new Percent(1.3)] }
     ]);
 
@@ -54,11 +54,11 @@ test("equality check (multiple filters in same order)", () => {
 
 test("equality check (different filters)", () => {
     const backdropFilter = new BackdropFilter([
-        { fn: "blur", args: [new Length(13, "px")] },
+        { fn: "blur", args: [new Length(13, { unit: "px" })] },
         { fn: "saturate", args: [new Percent(1.3)] }
     ]);
     const other = new BackdropFilter([
-        { fn: "blur", args: [new Length(13, "px")] }
+        { fn: "blur", args: [new Length(13, { unit: "px" })] }
     ]);
 
     expect(backdropFilter.equals(other)).toBe(false);
@@ -66,12 +66,12 @@ test("equality check (different filters)", () => {
 
 test("equality check (same filters in differing order)", () => {
     const backdropFilter = new BackdropFilter([
-        { fn: "blur", args: [new Length(13, "px")] },
+        { fn: "blur", args: [new Length(13, { unit: "px" })] },
         { fn: "saturate", args: [new Percent(1.3)] }
     ]);
     const other = new BackdropFilter([
         { fn: "saturate", args: [new Percent(1.3)] },
-        { fn: "blur", args: [new Length(13, "px")] }
+        { fn: "blur", args: [new Length(13, { unit: "px" })] }
     ]);
 
     expect(backdropFilter.equals(other)).toBe(false);

--- a/packages/zeplin-extension-style-kit/tests/declarations/borderRadius.test.js
+++ b/packages/zeplin-extension-style-kit/tests/declarations/borderRadius.test.js
@@ -11,7 +11,7 @@ test("property name", () => {
 test("border radius value", () => {
     const params = { densityDivisor: 2 };
     const radius = 20;
-    const borderRadius = new BorderRadius(new Length(radius, "px"));
+    const borderRadius = new BorderRadius(new Length(radius, { unit: "px" }));
 
     expect(borderRadius.getValue(params)).toBe(`${radius / params.densityDivisor}px`);
 });

--- a/packages/zeplin-extension-style-kit/tests/declarations/borderWidth.test.js
+++ b/packages/zeplin-extension-style-kit/tests/declarations/borderWidth.test.js
@@ -11,7 +11,7 @@ test("property name", () => {
 test("border-width value", () => {
     const params = { densityDivisor: 2 };
     const width = 2;
-    const borderWidth = new BorderWidth(new Length(width, "px"));
+    const borderWidth = new BorderWidth(new Length(width, { unit: "px" }));
 
     expect(borderWidth.getValue(params)).toBe(`${width / params.densityDivisor}px`);
 });

--- a/packages/zeplin-extension-style-kit/tests/declarations/filter.test.js
+++ b/packages/zeplin-extension-style-kit/tests/declarations/filter.test.js
@@ -5,7 +5,7 @@ import Percent from "@root/values/percent";
 
 test("property name", () => {
     const filter = new Filter([
-        { fn: "blur", args: [new Length(13, "px")] }
+        { fn: "blur", args: [new Length(13, { unit: "px" })] }
     ]);
 
     expect(filter.name).toBe("filter");
@@ -13,7 +13,7 @@ test("property name", () => {
 
 test("single filter", () => {
     const filter = new Filter([
-        { fn: "blur", args: [new Length(13, "px")] }
+        { fn: "blur", args: [new Length(13, { unit: "px" })] }
     ]);
 
     expect(filter.getValue({ densityDivisor: 1 })).toBe("blur(13px)");
@@ -21,7 +21,7 @@ test("single filter", () => {
 
 test("multiple filters", () => {
     const filter = new Filter([
-        { fn: "blur", args: [new Length(13, "px")] },
+        { fn: "blur", args: [new Length(13, { unit: "px" })] },
         { fn: "saturate", args: [new Percent(1.3)] }
     ]);
 
@@ -30,10 +30,10 @@ test("multiple filters", () => {
 
 test("equality check", () => {
     const filter = new Filter([
-        { fn: "blur", args: [new Length(13, "px")] }
+        { fn: "blur", args: [new Length(13, { unit: "px" })] }
     ]);
     const other = new Filter([
-        { fn: "blur", args: [new Length(13, "px")] }
+        { fn: "blur", args: [new Length(13, { unit: "px" })] }
     ]);
 
     expect(filter.equals(other)).toBe(true);
@@ -41,11 +41,11 @@ test("equality check", () => {
 
 test("equality check (multiple filters in same order)", () => {
     const filter = new Filter([
-        { fn: "blur", args: [new Length(13, "px")] },
+        { fn: "blur", args: [new Length(13, { unit: "px" })] },
         { fn: "saturate", args: [new Percent(1.3)] }
     ]);
     const other = new Filter([
-        { fn: "blur", args: [new Length(13, "px")] },
+        { fn: "blur", args: [new Length(13, { unit: "px" })] },
         { fn: "saturate", args: [new Percent(1.3)] }
     ]);
 
@@ -54,11 +54,11 @@ test("equality check (multiple filters in same order)", () => {
 
 test("equality check (different filters)", () => {
     const filter = new Filter([
-        { fn: "blur", args: [new Length(13, "px")] },
+        { fn: "blur", args: [new Length(13, { unit: "px" })] },
         { fn: "saturate", args: [new Percent(1.3)] }
     ]);
     const other = new Filter([
-        { fn: "blur", args: [new Length(13, "px")] }
+        { fn: "blur", args: [new Length(13, { unit: "px" })] }
     ]);
 
     expect(filter.equals(other)).toBe(false);
@@ -66,12 +66,12 @@ test("equality check (different filters)", () => {
 
 test("equality check (same filters in differing order)", () => {
     const filter = new Filter([
-        { fn: "blur", args: [new Length(13, "px")] },
+        { fn: "blur", args: [new Length(13, { unit: "px" })] },
         { fn: "saturate", args: [new Percent(1.3)] }
     ]);
     const other = new Filter([
         { fn: "saturate", args: [new Percent(1.3)] },
-        { fn: "blur", args: [new Length(13, "px")] }
+        { fn: "blur", args: [new Length(13, { unit: "px" })] }
     ]);
 
     expect(filter.equals(other)).toBe(false);

--- a/packages/zeplin-extension-style-kit/tests/declarations/fontSize.test.js
+++ b/packages/zeplin-extension-style-kit/tests/declarations/fontSize.test.js
@@ -11,7 +11,7 @@ test("property name", () => {
 test("font-size value", () => {
     const params = { densityDivisor: 2 };
     const size = 2;
-    const fontSize = new FontSize(new Length(size, "px"));
+    const fontSize = new FontSize(new Length(size, { unit: "px" }));
 
     expect(fontSize.getValue(params)).toBe(`${size / params.densityDivisor}px`);
 });

--- a/packages/zeplin-extension-style-kit/tests/declarations/height.test.js
+++ b/packages/zeplin-extension-style-kit/tests/declarations/height.test.js
@@ -11,7 +11,7 @@ test("property name", () => {
 test("height value", () => {
     const params = { densityDivisor: 2 };
     const heightValue = 2;
-    const height = new Height(new Length(heightValue, "px"));
+    const height = new Height(new Length(heightValue, { unit: "px" }));
 
     expect(height.getValue(params)).toBe(`${heightValue / params.densityDivisor}px`);
 });

--- a/packages/zeplin-extension-style-kit/tests/declarations/letterSpacing.test.js
+++ b/packages/zeplin-extension-style-kit/tests/declarations/letterSpacing.test.js
@@ -10,10 +10,10 @@ test("property name", () => {
 
 test("letter-spacing value", () => {
     const params = { densityDivisor: 2 };
-    const size = 2;
-    const letterSpacing = new LetterSpacing(new Length(size, { unit: "px" }));
+    const value = 2;
+    const letterSpacing = new LetterSpacing(value);
 
-    expect(letterSpacing.getValue(params)).toBe(`${size / params.densityDivisor}px`);
+    expect(letterSpacing.getValue(params)).toBe(`${value / params.densityDivisor}px`);
 });
 
 test("has default value", () => {
@@ -23,27 +23,33 @@ test("has default value", () => {
 });
 
 test("not have default value", () => {
-    const letterSpacing = new LetterSpacing(new Length(13));
+    const letterSpacing = new LetterSpacing(13);
 
     expect(letterSpacing.hasDefaultValue()).toBe(false);
 });
 
 test("has decimal value", () => {
-    const letterSpacing = new LetterSpacing(new Length(0.01));
+    const params = { densityDivisor: 2 };
+    const value = 0.04;
+    const letterSpacing = new LetterSpacing(value);
 
-    expect(letterSpacing.hasDefaultValue()).toBe(false);
+    expect(letterSpacing.getValue(params)).toBe(`${value / params.densityDivisor}px`);
 });
 
 test("equality check", () => {
-    const letterSpacing = new LetterSpacing(new Length(10));
-    const other = new LetterSpacing(new Length(10));
+    const value = 10;
+    const letterSpacing = new LetterSpacing(value);
+    const other = new LetterSpacing(value);
 
     expect(letterSpacing.equals(other)).toBe(true);
 });
 
 test("equality check (unequal)", () => {
-    const letterSpacing = new LetterSpacing(new Length(10));
-    const other = new LetterSpacing(new Length(20));
+    const value = 10;
+    const letterSpacing = new LetterSpacing(value);
+
+    const otherValue = 20;
+    const other = new LetterSpacing(otherValue);
 
     expect(letterSpacing.equals(other)).toBe(false);
 });

--- a/packages/zeplin-extension-style-kit/tests/declarations/letterSpacing.test.js
+++ b/packages/zeplin-extension-style-kit/tests/declarations/letterSpacing.test.js
@@ -11,7 +11,7 @@ test("property name", () => {
 test("letter-spacing value", () => {
     const params = { densityDivisor: 2 };
     const size = 2;
-    const letterSpacing = new LetterSpacing(new Length(size, "px"));
+    const letterSpacing = new LetterSpacing(new Length(size, { unit: "px" }));
 
     expect(letterSpacing.getValue(params)).toBe(`${size / params.densityDivisor}px`);
 });
@@ -24,6 +24,12 @@ test("has default value", () => {
 
 test("not have default value", () => {
     const letterSpacing = new LetterSpacing(new Length(13));
+
+    expect(letterSpacing.hasDefaultValue()).toBe(false);
+});
+
+test("has decimal value", () => {
+    const letterSpacing = new LetterSpacing(new Length(0.01));
 
     expect(letterSpacing.hasDefaultValue()).toBe(false);
 });

--- a/packages/zeplin-extension-style-kit/tests/declarations/transform.test.js
+++ b/packages/zeplin-extension-style-kit/tests/declarations/transform.test.js
@@ -5,7 +5,7 @@ import Scalar from "@root/values/scalar";
 
 test("property name", () => {
     const transform = new Transform([
-        { fn: "translateX", args: [new Length(13, "px")] }
+        { fn: "translateX", args: [new Length(13, { unit: "px" })] }
     ]);
 
     expect(transform.name).toBe("transform");
@@ -13,7 +13,7 @@ test("property name", () => {
 
 test("single transform", () => {
     const transform = new Transform([
-        { fn: "translateX", args: [new Length(13, "px")] }
+        { fn: "translateX", args: [new Length(13, { unit: "px" })] }
     ]);
 
     expect(transform.getValue({ densityDivisor: 1 })).toBe("translateX(13px)");
@@ -21,7 +21,7 @@ test("single transform", () => {
 
 test("multiple functions", () => {
     const transform = new Transform([
-        { fn: "translateX", args: [new Length(13, "px")] },
+        { fn: "translateX", args: [new Length(13, { unit: "px" })] },
         { fn: "scaleY", args: [new Scalar(0.3)] }
     ]);
 
@@ -30,10 +30,10 @@ test("multiple functions", () => {
 
 test("equality check", () => {
     const transform = new Transform([
-        { fn: "translateX", args: [new Length(13, "px")] }
+        { fn: "translateX", args: [new Length(13, { unit: "px" })] }
     ]);
     const other = new Transform([
-        { fn: "translateX", args: [new Length(13, "px")] }
+        { fn: "translateX", args: [new Length(13, { unit: "px" })] }
     ]);
 
     expect(transform.equals(other)).toBe(true);
@@ -41,11 +41,11 @@ test("equality check", () => {
 
 test("equality check (multiple functions in same order)", () => {
     const transform = new Transform([
-        { fn: "translateX", args: [new Length(13, "px")] },
+        { fn: "translateX", args: [new Length(13, { unit: "px" })] },
         { fn: "scaleY", args: [new Scalar(0.3)] }
     ]);
     const other = new Transform([
-        { fn: "translateX", args: [new Length(13, "px")] },
+        { fn: "translateX", args: [new Length(13, { unit: "px" })] },
         { fn: "scaleY", args: [new Scalar(0.3)] }
     ]);
 
@@ -54,11 +54,11 @@ test("equality check (multiple functions in same order)", () => {
 
 test("equality check (different functions)", () => {
     const transform = new Transform([
-        { fn: "translateX", args: [new Length(13, "px")] },
+        { fn: "translateX", args: [new Length(13, { unit: "px" })] },
         { fn: "scaleY", args: [new Scalar(0.3)] }
     ]);
     const other = new Transform([
-        { fn: "translateX", args: [new Length(13, "px")] }
+        { fn: "translateX", args: [new Length(13, { unit: "px" })] }
     ]);
 
     expect(transform.equals(other)).toBe(false);
@@ -66,12 +66,12 @@ test("equality check (different functions)", () => {
 
 test("equality check (same functions in differing order)", () => {
     const transform = new Transform([
-        { fn: "translateX", args: [new Length(13, "px")] },
+        { fn: "translateX", args: [new Length(13, { unit: "px" })] },
         { fn: "scaleY", args: [new Scalar(0.3)] }
     ]);
     const other = new Transform([
         { fn: "scaleY", args: [new Scalar(0.3)] },
-        { fn: "translateX", args: [new Length(13, "px")] }
+        { fn: "translateX", args: [new Length(13, { unit: "px" })] }
     ]);
 
     expect(transform.equals(other)).toBe(false);

--- a/packages/zeplin-extension-style-kit/tests/declarations/width.test.js
+++ b/packages/zeplin-extension-style-kit/tests/declarations/width.test.js
@@ -11,7 +11,7 @@ test("property name", () => {
 test("width value", () => {
     const params = { densityDivisor: 2 };
     const widthValue = 2;
-    const width = new Width(new Length(widthValue, "px"));
+    const width = new Width(new Length(widthValue, { unit: "px" }));
 
     expect(width.getValue(params)).toBe(`${widthValue / params.densityDivisor}px`);
 });

--- a/packages/zeplin-extension-style-kit/tests/values/length.test.js
+++ b/packages/zeplin-extension-style-kit/tests/values/length.test.js
@@ -13,13 +13,13 @@ test("decimal number precision is 1", () => {
 });
 
 test("length with specific unit", () => {
-    const length = new Length(3, "ch");
+    const length = new Length(3, { unit: "ch" });
 
     expect(length.toStyleValue({ densityDivisor: 1 })).toBe("3ch");
 });
 
 test("density divisor divides the value", () => {
-    const length = new Length(30, "px");
+    const length = new Length(30, { unit: "px" });
 
     expect(length.toStyleValue({ densityDivisor: 2 })).toBe("15px");
 });
@@ -39,7 +39,7 @@ test("equality check returns true if value and unit are equal", () => {
 
 test("equality check returns false if value does not match", () => {
     const length = new Length(13);
-    const other = new Length(13, "ch");
+    const other = new Length(13, { unit: "ch" });
 
     expect(length.equals(other)).toBe(false);
 });

--- a/packages/zeplin-extension-style-kit/values/length.d.ts
+++ b/packages/zeplin-extension-style-kit/values/length.d.ts
@@ -1,7 +1,7 @@
-import { LengthParams } from "../common";
+import { LengthParams, LengthOptions } from "../common";
 
 declare class Length {
-    constructor(value: number, unit = "px");
+    constructor(value: number, options?: LengthOptions);
 
     equals(other: Length): boolean;
 

--- a/packages/zeplin-extension-style-kit/values/length.js
+++ b/packages/zeplin-extension-style-kit/values/length.js
@@ -1,9 +1,10 @@
 import Scalar from "./scalar";
 
 class Length {
-    constructor(value, unit = "px") {
+    constructor(value, { unit = "px", precision = 1 } = {}) {
         this.value = value;
         this.unit = unit;
+        this.precision = precision;
     }
 
     valueOf() {
@@ -17,7 +18,7 @@ class Length {
     }
 
     toStyleValue({ densityDivisor }) {
-        return this.value === 0 ? "0" : `${new Scalar(this.value / densityDivisor).toStyleValue()}${this.unit}`;
+        return this.value === 0 ? "0" : `${new Scalar(this.value / densityDivisor, this.precision).toStyleValue()}${this.unit}`;
     }
 }
 

--- a/packages/zeplin-extension-style-kit/values/length.js
+++ b/packages/zeplin-extension-style-kit/values/length.js
@@ -17,7 +17,7 @@ class Length {
     }
 
     toStyleValue({ densityDivisor }) {
-        return this.value === 0 ? "0" : `${new Scalar(this.value / densityDivisor, 1).toStyleValue()}${this.unit}`;
+        return this.value === 0 ? "0" : `${new Scalar(this.value / densityDivisor).toStyleValue()}${this.unit}`;
     }
 }
 


### PR DESCRIPTION
Passing 1 digit precision to scalar values results in `0px` `letter-spacing` values when its numeric value is less than `0.1`.