### PR TITLE
Fix unexpected cases for layout fields

### DIFF
--- a/packages/zeplin-extension-style-kit/elements/layer.js
+++ b/packages/zeplin-extension-style-kit/elements/layer.js
@@ -311,7 +311,7 @@ class Layer {
             declarations.push(new FlexGrow(new Scalar(layoutGrow)));
         }
 
-        if (layout) {
+        if (layout && layout.direction) {
             const {
                 direction,
                 distribution,
@@ -329,7 +329,9 @@ class Layer {
             if (itemAlignment) {
                 declarations.push(new AlignItems(itemAlignment));
             }
-            declarations.push(new Gap(new Length(gap)));
+            if (gap > 0) {
+                declarations.push(new Gap(new Length(gap)));
+            }
         }
     }
 


### PR DESCRIPTION
## Change description

> With the newest changes, the direction field can be `undefined` when there is no auto-layout feature and there is padding for the related layer. Also, the gap field can be a negative number to represent a mixed gap.  

## Type of change
- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [x] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
