### PR TITLE
[EX-85] Fix inconsistency about selector naming between stylesheet and html extensions

### DIFF
--- a/packages/zeplin-extension-style-kit/elements/layer.js
+++ b/packages/zeplin-extension-style-kit/elements/layer.js
@@ -37,6 +37,8 @@ import TextStyle from "./textStyle";
 import RuleSet from "../ruleSet";
 import {
     blendColors,
+    isHtmlTag,
+    isTextRelatedTag,
     selectorize,
     webkit
 } from "../utils";
@@ -607,9 +609,14 @@ class Layer {
             return `img${className}`;
         }
 
-        const defaultTag = type === "text" ? "span" : "div";
+        if (type !== "text") {
+            return layerName || "div";
+        }
 
-        return layerName || defaultTag;
+        if (isHtmlTag(layerName) && !isTextRelatedTag(layerName)) {
+            return `.${layerName}`;
+        }
+        return layerName || "span";
     }
 
     get style() {

--- a/packages/zeplin-extension-style-kit/utils.d.ts
+++ b/packages/zeplin-extension-style-kit/utils.d.ts
@@ -2,6 +2,8 @@ import { StyleDeclaration } from "./common";
 
 declare function isHtmlTag(str: string): boolean;
 
+declare function isTextRelatedTag(str: string): boolean;
+
 declare function isDeclarationInherited(propName: string): boolean;
 
 declare function blendColors(colors: object[]): object;

--- a/packages/zeplin-extension-style-kit/utils.js
+++ b/packages/zeplin-extension-style-kit/utils.js
@@ -2,23 +2,26 @@ import cssEscape from "css.escape";
 import FontFace from "./elements/fontFace";
 import { OPTION_NAMES } from "./constants";
 
+const TEXT_RELATED_TAGS = [
+    "a", "abbr", "address", "article", "aside", "b", "bdi", "bdo", "blockquote", "button", "caption", "cite", "code",
+    "data", "dd", "del", "details", "dfn", "dialog", "div", "dt", "em", "figcaption", "footer", "h1", "h2", "h3", "h4",
+    "h5", "h6", "header", "i", "input", "ins", "kbd", "label", "legend", "li", "link", "main", "mark", "meter", "nav",
+    "option", "output", "p", "pre", "q", "rp", "rt", "ruby", "s", "samp", "section", "slot", "small", "span", "strong",
+    "sub", "summary", "sup", "td", "textarea", "th", "time", "u", "var"
+];
+
 const HTML_TAGS = [
-    "a", "abbr", "address", "area", "article", "aside", "audio", "b", "base", "bdi",
-    "bdo", "blockquote", "body", "br", "button", "canvas", "caption", "cite", "code",
-    "col", "colgroup", "data", "datalist", "dd", "del", "details", "dfn", "dialog",
-    "div", "dl", "dt", "em", "embed", "fieldset", "figcaption", "figure", "footer",
-    "form", "h1", "h2", "h3", "h4", "h5", "h6", "head", "header", "hgroup", "hr",
-    "html", "i", "iframe", "img", "input", "ins", "kbd", "keygen", "label", "legend",
-    "li", "link", "main", "map", "mark", "math", "menu", "menuitem", "meta", "meter",
-    "nav", "noscript", "object", "ol", "optgroup", "option", "output", "p", "param",
-    "picture", "pre", "progress", "q", "rp", "rt", "ruby", "s", "samp", "script",
-    "section", "select", "slot", "small", "source", "source", "span", "strong", "style",
-    "sub", "summary", "sup", "svg", "table", "tbody", "td", "template", "textarea",
-    "tfoot", "th", "thead", "time", "title", "tr", "track", "u", "ul", "var", "video", "wbr"
+    ...TEXT_RELATED_TAGS,
+    "audio", "body", "canvas", "datalist", "dl", "embed", "fieldset", "figure", "form", "iframe", "noscript", "ol",
+    "optgroup", "progress", "select", "table", "tbody", "tfoot", "thead", "tr", "ul"
 ];
 
 function isHtmlTag(str) {
     return HTML_TAGS.includes(str.toLowerCase());
+}
+
+function isTextRelatedTag(str) {
+    return TEXT_RELATED_TAGS.includes(str.toLowerCase());
 }
 
 const NOT_INHERITED_PROPS = [
@@ -233,6 +236,7 @@ export {
     getUniqueLayerTextStyles,
     getFontFaces,
     isHtmlTag,
+    isTextRelatedTag,
     isDeclarationInherited,
     selectorize,
     generateIdentifier,


### PR DESCRIPTION
## Change description


## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix EX-85 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [x] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
