### PR TITLE
ci: build dependencies before extensions

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Install Dependencies
         run: npm install
 
+      - name: Build zeplin-extension-style-kit and base-extension
+        run: npm run build --workspace=zeplin-extension-style-kit --workspace=base-extension
+
       - name: Build Target Package
         run: npm run build --workspace=$(echo $GITHUB_REF_NAME | cut -d'@' -f 1)
 


### PR DESCRIPTION
It is required to add this step since base packages are Typescript now.